### PR TITLE
Update faraday minimum version to 0.9 to fix a crash when using 0.8

### DIFF
--- a/danger.gemspec
+++ b/danger.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "claide-plugins", "> 0.9.0"
   spec.add_runtime_dependency "git", "~> 1"
   spec.add_runtime_dependency "colored", "~> 1.2"
-  spec.add_runtime_dependency "faraday", "~> 0"
+  spec.add_runtime_dependency "faraday", "~> 0.9"
   spec.add_runtime_dependency "faraday-http-cache", "~> 1.0"
   spec.add_runtime_dependency "octokit", "~> 4.2"
   spec.add_runtime_dependency "kramdown", "~> 1.5"


### PR DESCRIPTION
There was a breaking name change between faraday 0.8 and 0.9. Danger won't work with faraday 0.8.

```
$ bundle exec danger local --use-merged-pr=191
/Users/michele/.rvm/gems/ruby-2.3.0/gems/danger-2.1.5/lib/danger/commands/local.rb:64:in `run': uninitialized constant Faraday::RackBuilder (NameError)
Did you mean?  Faraday::Builder
    from /Users/michele/.rvm/gems/ruby-2.3.0/gems/claide-1.0.0/lib/claide/command.rb:334:in `run'
    from /Users/michele/.rvm/gems/ruby-2.3.0/gems/danger-2.1.5/bin/danger:5:in `<top (required)>'
    from /Users/michele/.rvm/gems/ruby-2.3.0/bin/danger:23:in `load'
    from /Users/michele/.rvm/gems/ruby-2.3.0/bin/danger:23:in `<main>'
    from /Users/michele/.rvm/gems/ruby-2.3.0/bin/ruby_executable_hooks:15:in `eval'
    from /Users/michele/.rvm/gems/ruby-2.3.0/bin/ruby_executable_hooks:15:in `<main>'
```

This just updates the minimum faraday version to 0.9.
